### PR TITLE
Fix possible fix(deps): 5 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )


### PR DESCRIPTION
This changes `go.mod` to address something a scan flagged. It is around line 1.

The application imports golang.org/x/net v0.53.0, which contains a flaw (CVE-2026-25681) where arbitrary HTML can be parsed and later rendered, leading to an unexpected HTML tree. An attacker can inject malicious markup that bypasses sanitization and triggers XSS when the content is rendered. This is a high‑severity issue because it can lead to credential theft, session hijacking, or other client‑side attacks. Updating to the fixed version (v0.55.0 or later) eliminates the vulnerable code path.

Upgrade indirect dependencies golang.org/x/net and golang.org/x/text to the latest versions that fix the reported CVEs.

For reference: rule `CVE-2026-25681`. Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
